### PR TITLE
Update the favicon for the search engine

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
     "chrome_settings_overrides" : {
        "search_provider" : {
           "encoding" : "UTF-8",
-          "favicon_url" : "https://www.wolframalpha.com/_next/static/images/favicon_fzx75d1e.ico",
+          "favicon_url" : "https://www.wolframalpha.com/favicon.ico",
           "is_default" : false,
           "keyword" : "=",
           "name" : "Wolfram|Alpha",


### PR DESCRIPTION
It seems that the original favicon referenced by the favicon_url property no longer exists, causing firefox to show only a magnifier icon in the search bar. Thus, the property is changed to reference the favicon.ico file in the base directory of the website. Many websites use this file as a fallback favicon for older browsers, so it is not likely to be removed in the near future.